### PR TITLE
[HCR-116] manual release workflow 경로 수정

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   release:
-    uses: one-year-gap/infra/.github/workflows/reusable-customer-web-manual-release.yml@main
+    uses: one-year-gap/infra/.github/workflows/customer-web-manual-release.yml@main
     with:
       source-ref: ${{ inputs.source-ref }}
       release-label: ${{ inputs.release-label }}


### PR DESCRIPTION
## 📝작업 내용
- `manual-release.yml`에서 reusable workflow 참조 경로 오타를 수정
- customer-web 수동 배포 워크플로우가 infra의 실제 파일명을 참조하도록 변경

<br/>

## 👀변경 사항
- 파일: `.github/workflows/manual-release.yml`
- 변경 전:
  - `one-year-gap/infra/.github/workflows/reusable-customer-web-manual-release.yml@main`
- 변경 후:
  - `one-year-gap/infra/.github/workflows/customer-web-manual-release.yml@main`
- 기대 효과:
  - `gh workflow run manual-release.yml ...` 실행 시 `HTTP 422 workflow was not found` 에러 해소

<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-116

<br/>

## #️⃣관련 이슈
- related #23
