### PR TITLE
[HSC-297] 개인별 상품 추천 페이지 API 연동

### DIFF
--- a/src/app/(service)/products/recommend/page.tsx
+++ b/src/app/(service)/products/recommend/page.tsx
@@ -6,6 +6,7 @@ import { ChevronRight } from "lucide-react";
 
 import CompareModal from "@/components/domain/products/modals/CompareModal";
 import DetailModal from "@/components/domain/products/modals/DetailModal";
+import { ProductsFilter } from "@/components/domain/products/ProductsFilter";
 import { ProductsHeader } from "@/components/domain/products/ProductsHeader";
 import { useRecommendPlan } from "@/lib/tanstack/query/useRecommendPlan";
 
@@ -13,40 +14,47 @@ type ModalType = "none" | "detail" | "compare";
 
 export default function RecommendPage() {
   const memberId = 1;
-
   const profileText = "사용자 프로필 텍스트";
 
   const { data, isLoading, isError } = useRecommendPlan(memberId, profileText);
 
   const [modal, setModal] = useState<ModalType>("none");
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [category, setCategory] = useState("recommend");
 
   const plans = data?.recommendedProducts ?? [];
 
-  if (isLoading) return <div className="px-4">추천 요금제 불러오는 중...</div>;
-  if (isError) return <div className="px-4">추천 요금제 불러오기 실패</div>;
-  if (plans.length === 0) return <div className="px-4">추천 요금제가 없습니다.</div>;
-
   return (
-    <div className="space-y-6 px-4 pb-24">
+    <div className="space-y-6 pb-24">
       <ProductsHeader />
 
-      <div className="space-y-4">
-        {plans.map((plan) => (
-          <RecommendCard
-            key={plan.productId}
-            planId={plan.productId}
-            name={plan.productName}
-            price={plan.productPrice}
-            salePrice={plan.salePrice}
-            reason={plan.reason}
-            onOpenDetail={(id) => {
-              setSelectedId(id);
-              setModal("detail");
-            }}
-          />
-        ))}
-      </div>
+      <ProductsFilter selected={category} onChange={setCategory} />
+
+      {isLoading && <div className="px-1 text-sm text-neutral-500">추천 요금제 불러오는 중...</div>}
+      {isError && <div className="px-1 text-sm text-red-500">추천 요금제 불러오기 실패</div>}
+
+      {!isLoading && !isError && plans.length === 0 && (
+        <div className="px-1 text-sm text-neutral-500">추천 요금제가 없습니다.</div>
+      )}
+
+      {!isLoading && !isError && plans.length > 0 && (
+        <div className="space-y-4">
+          {plans.map((plan) => (
+            <RecommendCard
+              key={plan.productId}
+              planId={plan.productId}
+              name={plan.productName}
+              price={plan.productPrice}
+              salePrice={plan.salePrice}
+              reason={plan.reason}
+              onOpenDetail={(id) => {
+                setSelectedId(id);
+                setModal("detail");
+              }}
+            />
+          ))}
+        </div>
+      )}
 
       <DetailModal
         open={modal === "detail"}
@@ -107,9 +115,10 @@ function RecommendCard({
         </button>
       </div>
 
-      <div className="mt-4 border-t pt-3">
-        <p className="text-secondary-700 text-sm font-semibold">추천 이유</p>
-        <p className="mt-2 text-xs text-neutral-700">{reason}</p>
+      {/* 추천 이유 */}
+      <div className="mt-4 rounded-lg bg-neutral-50 p-3">
+        <p className="text-secondary-700 text-xs font-semibold">추천 이유</p>
+        <p className="mt-1 text-xs leading-relaxed text-neutral-700">{reason}</p>
       </div>
     </div>
   );

--- a/src/app/(service)/products/recommend/page.tsx
+++ b/src/app/(service)/products/recommend/page.tsx
@@ -1,105 +1,115 @@
 "use client";
 
-import { ChevronRight, Smartphone, Wifi } from "lucide-react";
+import { useState } from "react";
 
+import { ChevronRight } from "lucide-react";
+
+import CompareModal from "@/components/domain/products/modals/CompareModal";
+import DetailModal from "@/components/domain/products/modals/DetailModal";
 import { ProductsHeader } from "@/components/domain/products/ProductsHeader";
+import { useRecommendPlan } from "@/lib/tanstack/query/useRecommendPlan";
 
-const MOCK_PLANS = [
-  {
-    id: 1,
-    name: "5G 프리미어 에센셜",
-    price: 69000,
-    data: "무제한 (일 2GB 후 3Mbps)",
-    call: "무제한",
-    reasons: [
-      "무제한 데이터를 충분한 데이터를 원하는 분들께 추천",
-      "넉넉한 데이터와 통화가 잦은 고객님께 무제한 통화 추천",
-    ],
-  },
-  {
-    id: 2,
-    name: "5G 프리미어 에센셜",
-    price: 69000,
-    data: "무제한 (일 2GB 후 3Mbps)",
-    call: "무제한",
-    reasons: [
-      "무제한 데이터를 충분한 데이터를 원하는 분들께 추천",
-      "넉넉한 데이터와 통화가 잦은 고객님께 무제한 통화 추천",
-    ],
-  },
-];
+type ModalType = "none" | "detail" | "compare";
 
 export default function RecommendPage() {
+  const memberId = 1;
+
+  const profileText = "사용자 프로필 텍스트";
+
+  const { data, isLoading, isError } = useRecommendPlan(memberId, profileText);
+
+  const [modal, setModal] = useState<ModalType>("none");
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const plans = data?.recommendedProducts ?? [];
+
+  if (isLoading) return <div className="px-4">추천 요금제 불러오는 중...</div>;
+  if (isError) return <div className="px-4">추천 요금제 불러오기 실패</div>;
+  if (plans.length === 0) return <div className="px-4">추천 요금제가 없습니다.</div>;
+
   return (
     <div className="space-y-6 px-4 pb-24">
       <ProductsHeader />
 
       <div className="space-y-4">
-        {MOCK_PLANS.map((plan) => (
-          <RecommendCard key={plan.id} plan={plan} />
+        {plans.map((plan) => (
+          <RecommendCard
+            key={plan.productId}
+            planId={plan.productId}
+            name={plan.productName}
+            price={plan.productPrice}
+            salePrice={plan.salePrice}
+            reason={plan.reason}
+            onOpenDetail={(id) => {
+              setSelectedId(id);
+              setModal("detail");
+            }}
+          />
         ))}
       </div>
+
+      <DetailModal
+        open={modal === "detail"}
+        productId={selectedId}
+        onClose={() => setModal("none")}
+        onCompare={() => setModal("compare")}
+      />
+
+      <CompareModal
+        open={modal === "compare"}
+        targetPlanId={selectedId}
+        onClose={() => setModal("none")}
+      />
     </div>
   );
 }
 
-interface Plan {
-  id: number;
+interface RecommendCardProps {
+  planId: number;
   name: string;
   price: number;
-  data: string;
-  call: string;
-  reasons: string[];
+  salePrice: number;
+  reason: string;
+  onOpenDetail: (id: number) => void;
 }
 
-function RecommendCard({ plan }: { plan: Plan }) {
+function RecommendCard({
+  planId,
+  name,
+  price,
+  salePrice,
+  reason,
+  onOpenDetail,
+}: RecommendCardProps) {
+  const savings = price - salePrice;
+
   return (
-    <div className="border-primary-200 bg-background rounded-2xl border-2 p-5">
+    <div className="border-primary-200 bg-background rounded-2xl border-2 p-5 shadow-sm">
       <span className="bg-primary-500 text-neutral-0 rounded-full px-3 py-1 text-xs font-semibold">
         추천
       </span>
+
       <div className="mt-2 flex items-center justify-between">
-        <div className="text-base font-bold text-neutral-800">{plan.name}</div>
+        <div className="text-base font-bold text-neutral-800">{name}</div>
 
         <p className="text-primary-500 font-bold">
-          {plan.price.toLocaleString()}
-          <span className="text- ml-1 text-xs">원/월</span>
+          {savings.toLocaleString()}
+          <span className="ml-1 text-xs">원 절약</span>
         </p>
       </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-6">
-        <div className="flex gap-2">
-          <Wifi size={18} className="text-secondary-700 mt-1" />
-          <div>
-            <p className="text-xs text-neutral-700">데이터</p>
-            <p className="text-sm font-bold">{plan.data}</p>
-          </div>
-        </div>
-
-        <div className="flex gap-2">
-          <Smartphone size={18} className="text-secondary-700 mt-1" />
-          <div>
-            <p className="text-xs text-neutral-700">통화</p>
-            <p className="text-sm font-bold">{plan.call}</p>
-          </div>
-        </div>
-      </div>
-
       <div className="mt-3 flex justify-end">
-        <button className="text-secondary-700 flex items-center gap-1 text-xs font-bold">
+        <button
+          onClick={() => onOpenDetail(planId)}
+          className="text-secondary-700 flex items-center gap-1 text-xs font-bold">
           상세보기
           <ChevronRight size={16} />
         </button>
       </div>
 
       <div className="mt-4 border-t pt-3">
-        <p className="text-secondary-700 text-sm font-semibold">추천이유</p>
-
-        <ul className="mt-2 space-y-1 text-xs text-neutral-700">
-          {plan.reasons.map((r, i) => (
-            <li key={i}>• {r}</li>
-          ))}
-        </ul>
+        <p className="text-secondary-700 text-sm font-semibold">추천 이유</p>
+        <p className="mt-2 text-xs text-neutral-700">{reason}</p>
       </div>
     </div>
   );

--- a/src/components/domain/products/ProductsFilter.tsx
+++ b/src/components/domain/products/ProductsFilter.tsx
@@ -34,6 +34,8 @@ export function ProductsFilter({ selected, onChange }: ProductsFilterProps) {
 
                 if (item.value === "recommend") {
                   router.push("/products/recommend");
+                } else {
+                  router.push("/products");
                 }
               }}
               className={`shrink-0 rounded-full px-4 py-2 text-sm font-semibold transition ${

--- a/src/components/domain/recommends/RecommendCard.tsx
+++ b/src/components/domain/recommends/RecommendCard.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+
+interface RecommendCardProps {
+  planId: number;
+  name: string;
+  savings: number;
+  reason: string;
+  onOpenDetail: (id: number) => void;
+}
+
+export default function RecommendCard({
+  planId,
+  name,
+  savings,
+  reason,
+  onOpenDetail,
+}: RecommendCardProps) {
+  return (
+    <div className="border-primary-200 bg-background rounded-2xl border-2 p-5 shadow-sm">
+      <span className="bg-primary-500 text-neutral-0 rounded-full px-3 py-1 text-xs font-semibold">
+        추천
+      </span>
+
+      <div className="mt-2 flex items-center justify-between">
+        <div className="text-base font-bold text-neutral-800">{name}</div>
+
+        <p className="text-primary-500 font-bold">
+          {savings.toLocaleString()}
+          <span className="ml-1 text-xs">원 절약</span>
+        </p>
+      </div>
+
+      <div className="mt-3 flex justify-end">
+        <button
+          onClick={() => onOpenDetail(planId)}
+          className="text-secondary-700 flex items-center gap-1 text-xs font-bold">
+          상세보기
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      <div className="mt-4 border-t pt-3">
+        <p className="text-secondary-700 text-sm font-semibold">추천 이유</p>
+
+        <p className="mt-2 text-xs text-neutral-700">{reason}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/tanstack/query/useRecommendPlan.ts
+++ b/src/lib/tanstack/query/useRecommendPlan.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getRecommendPlan } from "@/services/getRecommendPlan";
+
+export function useRecommendPlan(memberId: number, profileText: string) {
+  return useQuery({
+    queryKey: ["recommendPlan", memberId],
+    queryFn: () =>
+      getRecommendPlan({
+        member_id: memberId,
+        profile_text: profileText,
+      }),
+    retry: false,
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/src/models/recommendPlan.ts
+++ b/src/models/recommendPlan.ts
@@ -1,0 +1,24 @@
+export interface RecommendedProduct {
+  rank: number;
+  productId: number;
+  productName: string;
+  productType: string;
+  productPrice: number;
+  salePrice: number;
+  tags: string[];
+  reason: string;
+}
+
+export interface RecommendPlanData {
+  segment: string;
+  cachedLlmRecommendation: string;
+  recommendedProducts: RecommendedProduct[];
+  source: string;
+  updatedAt: string;
+}
+
+export interface RecommendPlanResponse {
+  status: string;
+  data: RecommendPlanData;
+  timestamp: string;
+}

--- a/src/services/getPlanCompare.ts
+++ b/src/services/getPlanCompare.ts
@@ -1,9 +1,8 @@
-import api from "axios";
-
+import { api } from "@/lib/axios";
 import type { PlanCompareResponseDTO } from "@/models/planCompare";
 
 export async function getPlanCompare(targetPlanId: number): Promise<PlanCompareResponseDTO> {
-  const res = await api.get("https://api.holliverse.site/api/v1/customer/plans/compare", {
+  const res = await api.get("/api/v1/customer/plans/compare", {
     params: { targetPlanId },
   });
 

--- a/src/services/getRecommendPlan.ts
+++ b/src/services/getRecommendPlan.ts
@@ -1,0 +1,15 @@
+import { api } from "@/lib/axios";
+import type { RecommendPlanResponse } from "@/models/recommendPlan";
+
+interface RecommendRequest {
+  member_id: number;
+  profile_text: string;
+}
+
+export async function getRecommendPlan(body: RecommendRequest) {
+  const res = await api.get<RecommendPlanResponse>("/api/v1/customer/recommendations", {
+    data: body,
+  });
+
+  return res.data.data;
+}

--- a/src/services/getRecommendPlan.ts
+++ b/src/services/getRecommendPlan.ts
@@ -8,7 +8,7 @@ interface RecommendRequest {
 
 export async function getRecommendPlan(body: RecommendRequest) {
   const res = await api.get<RecommendPlanResponse>("/api/v1/customer/recommendations", {
-    data: body,
+    params: body,
   });
 
   return res.data.data;


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
<img width="413" height="757" alt="image" src="https://github.com/user-attachments/assets/cf40529d-790b-4b4f-be61-c66553b6c983" />


<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-

<br/>

## #️⃣관련 이슈

- closes #62 


<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 서버에서 맞춤 추천 상품을 불러와 카드로 표시
  * 추천 사유와 예상 절약액(가격-판매가)을 주요 정보로 노출
  * 상세보기·비교 모달로 상품 열람 및 모달 간 이동 지원
  * 로딩·오류·빈 상태 UI 추가

* **Refactor**
  * 정적 MOCK 데이터에서 동적 데이터 기반 렌더링으로 전환
  * 카드 UI 간소화 및 시각적 개선(섀도우, 주요 정보 강조)

* **Bug Fixes**
  * 추천 탭 외 선택 시 일반 상품 목록으로 이동되도록 네비게이션 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->